### PR TITLE
remove optional deps b/c they require a GUI

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
   run:
     - python
     - matplotlib-base
+    # colorspacious is imported directly, not a soft optional dep
+    - colorspacious
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 13eea3c8994d8e303e32a2db0b3e686f6edfb41cb21e7b0e663c2b17eea9b03a
 
 build:
-  number: 2
+  number: 3
   noarch: python
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
 
@@ -20,9 +20,6 @@ requirements:
   run:
     - python
     - matplotlib-base
-    # these two are optional deps
-    - colorspacious
-    - viscm
 
 test:
   imports:


### PR DESCRIPTION
#15 has no effect b/c these optional dependencies still install mpl with a GUI. Let's remove the optional dependencies so users can benefit from a lighter package (qt alone is 100mb download and much more unpacked!).

xref.: https://github.com/pangeo-data/pangeo-stacks/pull/121